### PR TITLE
Replace __define_output_path() FATAL with OSError

### DIFF
--- a/smooth_logger/Logger.py
+++ b/smooth_logger/Logger.py
@@ -90,11 +90,10 @@ class Logger:
             )
             return path
         else:
-            print(
-                f"FATAL: Could not automatically create output folder for operating system: {os}."
-                + "You will need to manually pass a pre-defined config_path."
+            raise OSError(
+                f"Could not automatically create output folder for operating system: {os}. You"
+                + " will need to pass a manually-defined config_path."
             )
-            exit()
     
     def __display_log_entry(self,
                             entry: LogEntry,

--- a/smooth_logger/__init__.py
+++ b/smooth_logger/__init__.py
@@ -1,4 +1,5 @@
 from .enums import Categories
 
 from .Logger import Logger
+
 from .LogEntry import LogEntry


### PR DESCRIPTION
Closes #10.

This is the only warning/error I'll be replacing with an actual exception. A couple of other candidates are due to be removed with refactors that handle or prevent them. Other ones are small warnings that don't warrant an exception.
