### PR TITLE
Fix crash on creating new log entry

### DIFF
--- a/smooth_logger/Logger.py
+++ b/smooth_logger/Logger.py
@@ -280,7 +280,7 @@ class Logger:
             )
             
             entry: LogEntry = self.__create_log_entry(message, output, scope)
-            self.__display_log_entry(entry, scope, notify, is_bar, print_to_console)
+            self.__display_log_entry(entry, scope, notify, print_to_console)
 
             self.__write_logs = self.__write_logs or output
             self.is_empty = False


### PR DESCRIPTION
The call to __display_log_entry() still attempted to pass is_bar, which doesn't exist any more.
