### PR TITLE
Switch from typing_extensions to typing

### DIFF
--- a/smooth_logger/Logger.py
+++ b/smooth_logger/Logger.py
@@ -4,7 +4,7 @@ from os.path import expanduser, isdir
 from plyer import notification
 from plyer.facades import Notification
 from time import time
-from typing_extensions import Union
+from typing import Union
 
 from .enums import Categories
 from .LogEntry import LogEntry


### PR DESCRIPTION
Union is now included in the main typing module and has been for a while. typing_extensions is redundant.
